### PR TITLE
Trigger animation via button

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
-    <section class="hero">
+    <section class="hero page">
       <div class="hero-img-container">
         <img src="/hero-img-layer-1.jpg" alt="" />
 
@@ -18,7 +18,7 @@
         <img src="/hero-img-layer-2.png" alt="" />
 
         <div class="hero-img-copy">
-          <p>Scroll down to reveal</p>
+          <p>Press the button to reveal</p>
         </div>
       </div>
 
@@ -50,10 +50,13 @@
           By Codegrid
         </h1>
       </div>
+
+      <button class="enter-button">Enter</button>
     </section>
 
-    <section class="outro">
+    <section class="outro page hidden">
       <p>Build your empire. Rule your city.</p>
+      <button class="back-button">Back</button>
     </section>
 
     <script type="module" src="/logo.js"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "gsap": "^3.13.0",
-        "lenis": "^1.3.1",
         "vite": "^6.3.5"
       }
     },
@@ -703,31 +702,6 @@
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.13.0.tgz",
       "integrity": "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw=="
-    },
-    "node_modules/lenis": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/lenis/-/lenis-1.3.1.tgz",
-      "integrity": "sha512-OGRlQk7EkGUtjDdnH+U49Mp26G/wGJFHuyYJ8ZwATllwHQZOKYbeuVaPWYQ4lK0gHfAnk2m0u8qN8Y4dtrHaHw==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/darkroomengineering"
-      },
-      "peerDependencies": {
-        "@nuxt/kit": ">=3.0.0",
-        "react": ">=17.0.0",
-        "vue": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@nuxt/kit": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        }
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "license": "ISC",
   "dependencies": {
     "gsap": "^3.13.0",
-    "lenis": "^1.3.1",
     "vite": "^6.3.5"
   }
 }

--- a/script.js
+++ b/script.js
@@ -1,10 +1,6 @@
 import { logoData } from "./logo";
 
 import gsap from "gsap";
-import ScrollTrigger from "gsap/ScrollTrigger";
-import Lenis from "lenis";
-
-gsap.registerPlugin(ScrollTrigger);
 
 document.addEventListener("DOMContentLoaded", () => {
   const overlay = document.querySelector(".overlay");
@@ -15,19 +11,16 @@ document.addEventListener("DOMContentLoaded", () => {
   overlay.style.left = "0";
   overlay.style.transform = "none";
 
-  const lenis = new Lenis();
-  lenis.on("scroll", ScrollTrigger.update);
-  gsap.ticker.add((time) => {
-    lenis.raf(time * 1000);
-  });
-  gsap.ticker.lagSmoothing(0);
+  const hero = document.querySelector(".hero");
+  const outro = document.querySelector(".outro");
 
   const heroImgContainer = document.querySelector(".hero-img-container");
   const heroImgLogo = document.querySelector(".hero-img-logo");
   const heroImgCopy = document.querySelector(".hero-img-copy");
   const fadeOverlay = document.querySelector(".fade-overlay");
   const svgOverlay = document.querySelector(".overlay");
-  const overlayCopy = document.querySelector("h1");
+  const overlayCopy = document.querySelector(".overlay-copy h1");
+  const startButton = document.querySelector(".enter-button");
 
   const initialOverlayScale = 500;
   const logoContainer = document.querySelector(".logo-container");
@@ -61,101 +54,47 @@ document.addEventListener("DOMContentLoaded", () => {
   updateLogoMask();
 
   gsap.set(svgOverlay, {
-    transformOrigin: "50% 50%",
-    xPercent: 0,
-    yPercent: 0,
-    left: 0,
-    top: 0,
+    transformOrigin: "50% 25%",
     scale: initialOverlayScale,
   });
+  gsap.set(heroImgContainer, { scale: 1.5 });
 
-  let scrollTriggerInstance;
-
-  function setupScrollTrigger() {
-    if (scrollTriggerInstance) {
-      scrollTriggerInstance.kill();
-    }
-
-    scrollTriggerInstance = ScrollTrigger.create({
-      trigger: ".hero",
-      start: "top top",
-      end: `+=${window.innerHeight * 5}px`,
-      pin: true,
-      pinSpacing: true,
-      scrub: 1,
-      onUpdate: (self) => {
-        const scrollProgress = self.progress;
-        const fadeOpacity = 1 - scrollProgress * (1 / 0.15);
-
-        if (scrollProgress <= 0.15) {
-          gsap.set([heroImgLogo, heroImgCopy], {
-            opacity: fadeOpacity,
-          });
-        } else {
-          gsap.set([heroImgLogo, heroImgCopy], {
-            opacity: 0,
-          });
-        }
-
-        if (scrollProgress <= 0.85) {
-          const normalizedProgress = scrollProgress * (1 / 0.85);
-          const heroImgContainerScale = 1.5 - 0.5 * normalizedProgress;
-          const overlayScale =
-            initialOverlayScale *
-            Math.pow(1 / initialOverlayScale, normalizedProgress);
-          let fadeOverlayOpacity = 0;
-
-          gsap.set(heroImgContainer, {
-            scale: heroImgContainerScale,
-          });
-
-          gsap.set(svgOverlay, {
-            transformOrigin: "50% 25%",
-            scale: overlayScale,
-            force3D: true,
-          });
-
-          if (scrollProgress >= 0.25) {
-            fadeOverlayOpacity = Math.min(
-              1,
-              (scrollProgress - 0.25) * (1 / 0.4)
-            );
-          }
-
-          gsap.set(fadeOverlay, {
-            opacity: fadeOverlayOpacity,
-          });
-        }
-
-        if (scrollProgress >= 0.7 && scrollProgress <= 0.85) {
-          const overlayCopyRevealProgress = (scrollProgress - 0.7) * (1 / 0.15);
-
-          const gradientSpread = 100;
-          const gradientBottomPosition = 240 - overlayCopyRevealProgress * 280;
-          const gradientTopPosition = gradientBottomPosition - gradientSpread;
-          const overlayCopyScale = 1.25 - 0.25 * overlayCopyRevealProgress;
-
-          overlayCopy.style.background = `linear-gradient(to bottom, #111117 0%, #111117 ${gradientTopPosition}%, #e66461 ${gradientBottomPosition}%, #e66461 100%)`;
-          overlayCopy.style.backgroundClip = "text";
-
-          gsap.set(overlayCopy, {
-            scale: overlayCopyScale,
-            opacity: overlayCopyRevealProgress,
-          });
-        } else if (scrollProgress < 0.7) {
-          gsap.set(overlayCopy, {
-            opacity: 0,
-          });
-        }
+  function transitionToOutro() {
+    const tl = gsap.timeline({
+      onComplete: () => {
+        hero.classList.add("hidden");
+        outro.classList.remove("hidden");
       },
     });
+
+    tl.to([heroImgLogo, heroImgCopy], { opacity: 0, duration: 0.3 });
+    tl.to(heroImgContainer, { scale: 1, duration: 1.5 }, "<");
+    tl.to(svgOverlay, { scale: 1, duration: 1.5 }, "<");
+    tl.to(fadeOverlay, { opacity: 1, duration: 0.6 }, "-=0.6");
+    tl.to(overlayCopy, { opacity: 1, duration: 0.6, scale: 1 }, "-=0.6");
   }
 
-  setupScrollTrigger();
+  function transitionToHero() {
+    hero.classList.remove("hidden");
+    const tl = gsap.timeline({
+      onComplete: () => {
+        outro.classList.add("hidden");
+      },
+    });
 
-  window.addEventListener("resize", () => {
-    updateLogoMask();
-    ScrollTrigger.refresh();
-    setupScrollTrigger();
-  });
+    tl.to([overlayCopy], { opacity: 0, duration: 0.3 });
+    tl.to(fadeOverlay, { opacity: 0, duration: 0.3 }, "<");
+    tl.to(svgOverlay, { scale: initialOverlayScale, duration: 1.5 }, "<");
+    tl.to(heroImgContainer, { scale: 1.5, duration: 1.5 }, "<");
+    tl.to([heroImgLogo, heroImgCopy], { opacity: 1, duration: 0.3 }, "-=1.2");
+  }
+
+  startButton.addEventListener("click", transitionToOutro);
+
+  const backButton = document.querySelector(".back-button");
+  if (backButton) {
+    backButton.addEventListener("click", transitionToHero);
+  }
+
+  window.addEventListener("resize", updateLogoMask);
 });

--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,7 @@ p {
   line-height: 0.8;
 }
 
+
 section {
   position: relative;
   width: 100vw;
@@ -41,6 +42,18 @@ section {
   background-color: #111117;
   text-align: center;
   overflow: hidden;
+}
+
+.page {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
+.hidden {
+  display: none;
 }
 
 .hero-img-container,
@@ -139,7 +152,8 @@ section {
   }
 }
 
-.enter-button {
+.enter-button,
+.back-button {
   position: absolute;
   bottom: 10%;
   left: 50%;
@@ -154,6 +168,7 @@ section {
   transition: background-color 0.3s ease;
 }
 
-.enter-button:hover {
+.enter-button:hover,
+.back-button:hover {
   background-color: #c25350;
 }


### PR DESCRIPTION
## Summary
- update markup so hero and outro behave as separate pages
- remove scroll-based logic and switch with GSAP animation via buttons
- drop the unused lenis dependency

## Testing
- `npm run build` *(fails: vite: Permission denied)*
- `node node_modules/vite/bin/vite.js build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*


------
https://chatgpt.com/codex/tasks/task_e_684d5af1dcb083238a3d0ce2624e3c7f